### PR TITLE
Update @types/telegram-web-app to 1.0.1 (Bot API 6.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@types/telegram-web-app": "^1.0.0"
+    "@types/telegram-web-app": "^1.0.1"
   }
 }


### PR DESCRIPTION
This PR just updates package @types/telegram-web-app to 1.0.1 to add compatibility with Bot API 6.1.